### PR TITLE
Fix for note about dump.log

### DIFF
--- a/base/logger/DESCRIPTION
+++ b/base/logger/DESCRIPTION
@@ -7,7 +7,8 @@ Authors@R: c(person("Rob", "Kooper", role = c("aut", "cre"),
              person("Alexey", "Shiklomanov", role = c("aut"),
                 email = "ashiklom@bu.edu"),
              person("Shashank", "Singh", role = c("aut"),
-                email = "shashanksingh819@gmail.com"))
+                email = "shashanksingh819@gmail.com"),
+             person("Chris", "Black", role = c("ctb")))
 Description: Special logger functions for tracking execution status and the environment.
 Imports: utils
 Suggests: testthat

--- a/base/logger/DESCRIPTION
+++ b/base/logger/DESCRIPTION
@@ -13,6 +13,5 @@ Imports: utils
 Suggests: testthat
 License: BSD_3_clause + file LICENSE
 Encoding: UTF-8
-LazyData: true
 RoxygenNote: 7.0.2
 Roxygen: list(markdown = TRUE)

--- a/base/logger/R/logger.R
+++ b/base/logger/R/logger.R
@@ -88,9 +88,9 @@ logger.error <- function(msg, ...) {
 ##' Prints an severe message and stops execution.
 ##' 
 ##' This function will print a message and stop execution of the code. This
-##' should only be used if the application should terminate. 
+##' should only be used if the application should terminate.
 ##' 
-##' set \code{\link{logger.setQuitOnSevere(FALSE)}}. To avoid terminating
+##' set \code{logger.setQuitOnSevere(FALSE)} to avoid terminating
 ##' the session. This is set by default to TRUE if interactive or running
 ##' inside Rstudio.
 ##'
@@ -140,8 +140,9 @@ logger.severe <- function(msg, ..., wrap = TRUE) {
 ##' }
 logger.message <- function(level, msg, ..., wrap = TRUE) {
   if (logger.getLevelNumber(level) >= .utils.logger$level) {
-    utils::dump.frames(dumpto = "dump.log")
-    calls <- names(dump.log)
+    call_dump <- NULL # to avoid "no visible binding" note from R check
+    utils::dump.frames(dumpto = "call_dump")
+    calls <- names(call_dump)
     calls <- calls[!grepl("^(#[0-9]+: )?(PEcAn\\.logger::)?logger", calls)]
     calls <- calls[!grepl("(severe|error|warn|info|debug)ifnot", calls)]
     func <- sub("\\(.*", "", utils::tail(calls, 1))

--- a/base/logger/R/logger.R
+++ b/base/logger/R/logger.R
@@ -90,7 +90,7 @@ logger.error <- function(msg, ...) {
 ##' This function will print a message and stop execution of the code. This
 ##' should only be used if the application should terminate.
 ##' 
-##' set \code{logger.setQuitOnSevere(FALSE)} to avoid terminating
+##' set \code{\link{logger.setQuitOnSevere}(FALSE)} to avoid terminating
 ##' the session. This is set by default to TRUE if interactive or running
 ##' inside Rstudio.
 ##'

--- a/base/logger/man/logger.severe.Rd
+++ b/base/logger/man/logger.severe.Rd
@@ -20,7 +20,7 @@ This function will print a message and stop execution of the code. This
 should only be used if the application should terminate.
 }
 \details{
-set \code{logger.setQuitOnSevere(FALSE)} to avoid terminating
+set \code{\link{logger.setQuitOnSevere}(FALSE)} to avoid terminating
 the session. This is set by default to TRUE if interactive or running
 inside Rstudio.
 }

--- a/base/logger/man/logger.severe.Rd
+++ b/base/logger/man/logger.severe.Rd
@@ -20,7 +20,7 @@ This function will print a message and stop execution of the code. This
 should only be used if the application should terminate.
 }
 \details{
-set \code{\link{logger.setQuitOnSevere(FALSE)}}. To avoid terminating
+set \code{logger.setQuitOnSevere(FALSE)} to avoid terminating
 the session. This is set by default to TRUE if interactive or running
 inside Rstudio.
 }


### PR DESCRIPTION
Fixes NOTE "no visible binding for global variable ‘dump.log’" from `R CMD check` plus a couple other small issues I saw while I was at it, and adds me as a contributor.